### PR TITLE
Force user into account selection using Minecraft oauth login

### DIFF
--- a/OAuth/AspNet.Security.OAuth.Minecraft/MinecraftAuthenticationHandler.cs
+++ b/OAuth/AspNet.Security.OAuth.Minecraft/MinecraftAuthenticationHandler.cs
@@ -39,6 +39,7 @@ namespace AspNet.Security.OAuth.Minecraft
                 {"code", context.Code},
                 {"scope", "Xboxlive.signin Xboxlive.offline_access"},
                 {"grant_type", "authorization_code"},
+                {"prompt", "select_account"},
             };
 
             // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow you may add `prompt=select_account` to prevent standard SSO behaviour and force users to first select any of their currently logged in accounts.

This is due to many complaints about Patreons logging in with a wrong Microsoft account.